### PR TITLE
Also publish as the latest major version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,7 @@ dependencies:
   override:
     - docker info
     - docker build -t brunoric/percona-toolkit:3.0.1 .
+    - docker build -t brunoric/percona-toolkit:3 .
     - docker build -t brunoric/percona-toolkit:latest .
     
 test:
@@ -21,4 +22,5 @@ deployment:
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push brunoric/percona-toolkit:3.0.1
+      - docker push brunoric/percona-toolkit:3
       - docker push brunoric/percona-toolkit:latest


### PR DESCRIPTION
Since you're automatically publishing the _exact_ version, you also might want to 'simplify' the usage and include a major version release tag... (thus allowing for easier usage by just `docker pull brunoric/percona-toolkit:3`